### PR TITLE
fix: clint send_soft max_hart_id times

### DIFF
--- a/rustsbi-qemu/src/feature.rs
+++ b/rustsbi-qemu/src/feature.rs
@@ -2,4 +2,4 @@ mod emulate_rdtime;
 mod transfer_trap;
 
 pub use emulate_rdtime::emulate_rdtime;
-pub use transfer_trap::{should_transfer_trap, do_transfer_trap};
+pub use transfer_trap::{do_transfer_trap, should_transfer_trap};

--- a/rustsbi-qemu/src/feature/transfer_trap.rs
+++ b/rustsbi-qemu/src/feature/transfer_trap.rs
@@ -1,6 +1,7 @@
 use crate::runtime::SupervisorContext;
 use riscv::register::{
-    scause, stval, mtval, sepc, mstatus::{self, MPP, SPP}, stvec
+    mstatus::{self, MPP, SPP},
+    mtval, scause, sepc, stval, stvec,
 };
 
 #[inline]

--- a/rustsbi-qemu/src/main.rs
+++ b/rustsbi-qemu/src/main.rs
@@ -16,9 +16,9 @@ mod execute;
 mod feature;
 mod hart_csr_utils;
 mod ns16550a;
+mod qemu_hsm;
 mod runtime;
 mod test_device;
-mod qemu_hsm;
 
 use buddy_system_allocator::LockedHeap;
 use core::panic::PanicInfo;
@@ -74,7 +74,8 @@ extern "C" fn rust_main(hartid: usize, opqaue: usize) -> ! {
     }
     delegate_interrupt_exception();
     set_pmp();
-    unsafe { // enable wake by ipi
+    unsafe {
+        // enable wake by ipi
         riscv::register::mstatus::set_mie();
     }
     if hartid == 0 {
@@ -82,8 +83,8 @@ extern "C" fn rust_main(hartid: usize, opqaue: usize) -> ! {
         hart_csr_utils::print_hart_csrs();
         // start other harts
         let clint = clint::Clint::new(0x2000000 as *mut u8);
-        let max_hart_id = * { count_harts::MAX_HART_ID.lock() };
-        for target_hart_id in 0..=max_hart_id {
+        let max_hart_id = *{ count_harts::MAX_HART_ID.lock() };
+        for target_hart_id in 0..max_hart_id {
             if target_hart_id != 0 {
                 clint.send_soft(target_hart_id);
             }

--- a/rustsbi-qemu/src/qemu_hsm.rs
+++ b/rustsbi-qemu/src/qemu_hsm.rs
@@ -1,10 +1,10 @@
 //! Hart state monitor designed for QEMU
 
-use hashbrown::HashMap;
-use rustsbi::SbiRet;
-use core::sync::atomic::{AtomicU8, Ordering};
 use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU8, Ordering};
+use hashbrown::HashMap;
 use riscv::register::mstatus::{self, MPP};
+use rustsbi::SbiRet;
 
 #[allow(unused)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -12,22 +12,22 @@ use riscv::register::mstatus::{self, MPP};
 enum HsmState {
     /// The hart is physically powered-up and executing normally.
     Started = 0,
-    /// The hart is not executing in supervisor-mode or any lower privilege mode. 
-    /// It is probably powered-down by the SBI implementation if the underlying platform has a mechanism 
+    /// The hart is not executing in supervisor-mode or any lower privilege mode.
+    /// It is probably powered-down by the SBI implementation if the underlying platform has a mechanism
     /// to physically power-down harts.
     Stopped = 1,
-    /// Some other hart has requested to start (or power-up) the hart from the STOPPED state 
+    /// Some other hart has requested to start (or power-up) the hart from the STOPPED state
     /// and the SBI implementation is still working to get the hart in the STARTED state.
     StartPending = 2,
-    /// The hart has requested to stop (or power-down) itself from the STARTED state 
+    /// The hart has requested to stop (or power-down) itself from the STARTED state
     /// and the SBI implementation is still working to get the hart in the STOPPED state.
     StopPending = 3,
     /// This hart is in a platform specific suspend (or low power) state.
     Suspended = 4,
-    /// The hart has requested to put itself in a platform specific low power state from the STARTED state 
+    /// The hart has requested to put itself in a platform specific low power state from the STARTED state
     /// and the SBI implementation is still working to get the hart in the platform specific SUSPENDED state.
     SuspendPending = 5,
-    /// An interrupt or platform specific hardware event has caused the hart to resume normal execution from 
+    /// An interrupt or platform specific hardware event has caused the hart to resume normal execution from
     /// the SUSPENDED state and the SBI implementation is still working to get the hart in the STARTED state.
     ResumePending = 6,
 }
@@ -61,12 +61,16 @@ impl QemuHsm {
     }
     pub(crate) fn record_current_stop_finished(&self) {
         let hart_id = riscv::register::mhartid::read();
-        self.state.lock().entry(hart_id)
+        self.state
+            .lock()
+            .entry(hart_id)
             .insert(AtomicU8::new(HsmState::Stopped as u8));
     }
     pub(crate) fn record_current_start_finished(&self) {
         let hart_id = riscv::register::mhartid::read();
-        self.state.lock().entry(hart_id)
+        self.state
+            .lock()
+            .entry(hart_id)
             .insert(AtomicU8::new(HsmState::Started as u8));
     }
 }
@@ -76,28 +80,31 @@ impl rustsbi::Hsm for QemuHsm {
         // previous privileged mode should be user or supervisor; start from machine mode is not supported
         let mpp = mstatus::read().mpp();
         if mpp != MPP::Supervisor && mpp != MPP::User {
-            return SbiRet::invalid_param()
-        }          
+            return SbiRet::invalid_param();
+        }
         // try to modify state to start hart
         let mut state_lock = self.state.lock();
-        let current_state = state_lock.entry(hart_id)
+        let current_state = state_lock
+            .entry(hart_id)
             .or_insert(AtomicU8::new(HsmState::Stopped as u8))
             .compare_exchange(
                 HsmState::Stopped as u8,
                 HsmState::StartPending as u8,
                 Ordering::AcqRel,
                 Ordering::Acquire,
-            ); 
+            );
         if current_state == Err(HsmState::Started as u8) {
-            return SbiRet::already_available()
+            return SbiRet::already_available();
         }
         // hart is already transitioning from started state
         if current_state != Ok(HsmState::Stopped as u8) {
-            return SbiRet::invalid_param()
+            return SbiRet::invalid_param();
         }
         // fill in the parameter
         let mut config_lock = self.last_command.lock();
-        config_lock.entry(hart_id).insert(HsmCommand::Start(start_addr, opaque));
+        config_lock
+            .entry(hart_id)
+            .insert(HsmCommand::Start(start_addr, opaque));
         drop(config_lock);
         drop(state_lock);
         // now, start the target hart
@@ -108,23 +115,24 @@ impl rustsbi::Hsm for QemuHsm {
     fn hart_stop(&self, hart_id: usize) -> SbiRet {
         // try to set current target hart state to stop pending
         let mut state_lock = self.state.lock();
-        let current_state = state_lock.entry(hart_id)
+        let current_state = state_lock
+            .entry(hart_id)
             .or_insert(AtomicU8::new(HsmState::Stopped as u8))
             .compare_exchange(
                 HsmState::Started as u8,
                 HsmState::StopPending as u8,
                 Ordering::AcqRel,
                 Ordering::Acquire,
-            ); 
+            );
         // check current hart state
         if current_state == Err(HsmState::Started as u8) {
-            return SbiRet::failed() // illegal state
+            return SbiRet::failed(); // illegal state
         }
         // fill in the parameter
         let mut config_lock = self.last_command.lock();
         config_lock.entry(hart_id).insert(HsmCommand::Stop);
         drop(config_lock);
-        drop(state_lock); 
+        drop(state_lock);
         // stop the target hart
         let clint = crate::clint::Clint::new(0x2000000 as *mut u8);
         clint.send_soft(hart_id);
@@ -133,20 +141,20 @@ impl rustsbi::Hsm for QemuHsm {
     fn hart_get_status(&self, hart_id: usize) -> SbiRet {
         self.state.lock().get(&hart_id).map_or(
             SbiRet::invalid_param(), // if given hart is invalid
-            |a| SbiRet::ok(a.load(Ordering::Relaxed) as usize)
+            |a| SbiRet::ok(a.load(Ordering::Relaxed) as usize),
         )
     }
     fn hart_suspend(&self, suspend_type: u32, resume_addr: usize, opaque: usize) -> SbiRet {
-        match suspend_type {    
-            // Resuming from a retentive suspend state is straight forward and the supervisor-mode software 
+        match suspend_type {
+            // Resuming from a retentive suspend state is straight forward and the supervisor-mode software
             // will see SBI suspend call return without any failures.
             SUSPEND_RETENTIVE => {
                 pause(); // pause and wait for machine level ipi
                 SbiRet::ok(0)
-            },
-            // Resuming from a non-retentive suspend state is relatively more involved and requires software 
-            // to restore various hart registers and CSRs for all privilege modes. 
-            // Upon resuming from non-retentive suspend state, the hart will jump to supervisor-mode at address 
+            }
+            // Resuming from a non-retentive suspend state is relatively more involved and requires software
+            // to restore various hart registers and CSRs for all privilege modes.
+            // Upon resuming from non-retentive suspend state, the hart will jump to supervisor-mode at address
             // specified by `resume_addr` with specific registers values described in the table below:
             //
             // | Register Name | Register Value
@@ -178,8 +186,8 @@ impl rustsbi::Hsm for QemuHsm {
                         unimplemented!("not RISC-V instruction set architecture")
                     }
                 };
-            },
-            _ => SbiRet::not_supported()
+            }
+            _ => SbiRet::not_supported(),
         }
     }
 }
@@ -189,10 +197,10 @@ const SUSPEND_NON_RETENTIVE: u32 = 0x80000000;
 
 // Pause current hart, wake through inter-processor interrupt
 pub fn pause() {
-    use riscv::asm::wfi;
-    use riscv::register::{mie, mip, mhartid};
     use crate::clint::Clint;
-    unsafe { 
+    use riscv::asm::wfi;
+    use riscv::register::{mhartid, mie, mip};
+    unsafe {
         let hartid = mhartid::read();
         let clint = Clint::new(0x2000000 as *mut u8);
         clint.clear_soft(hartid); // Clear IPI
@@ -208,5 +216,5 @@ pub fn pause() {
             mie::clear_msoft(); // Stop listening for software interrupts
         }
         clint.clear_soft(hartid); // Clear IPI
-    } 
+    }
 }

--- a/test-kernel/src/main.rs
+++ b/test-kernel/src/main.rs
@@ -6,8 +6,8 @@
 
 #[macro_use]
 mod console;
-mod sbi;
 mod mm;
+mod sbi;
 
 use riscv::register::{
     scause::{self, Exception, Trap},
@@ -16,7 +16,8 @@ use riscv::register::{
 };
 
 pub extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
-    if hartid == 0 { // initialization
+    if hartid == 0 {
+        // initialization
         mm::init_heap();
     }
     if hartid == 0 {
@@ -26,7 +27,7 @@ pub extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
         );
         test_base_extension();
         test_sbi_ins_emulation();
-    } 
+    }
     if hartid == 0 {
         let sbi_ret = sbi::hart_stop(1);
         println!(">> Stop hart 1, return value {:?}", sbi_ret);
@@ -36,13 +37,19 @@ pub extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
         }
     } else {
         let sbi_ret = sbi::hart_suspend(0x00000000, 0, 0);
-        println!(">> Start test for hart {}, suspend return value {:?}", hartid, sbi_ret);
+        println!(
+            ">> Start test for hart {}, suspend return value {:?}",
+            hartid, sbi_ret
+        );
     }
     unsafe { stvec::write(start_trap as usize, TrapMode::Direct) };
     println!(">> Test-kernel: Trigger illegal exception");
     unsafe { asm!("csrw mcycle, x0") }; // mcycle cannot be written, this is always a 4-byte illegal instruction
     if hartid != 3 {
-        println!("<< Test-kernel: test for hart {} success, wake another hart", hartid);
+        println!(
+            "<< Test-kernel: test for hart {} success, wake another hart",
+            hartid
+        );
         let bv: usize = 0b10;
         let sbi_ret = sbi::send_ipi(&bv as *const _ as usize, hartid); // wake hartid + 1
         println!(">> Wake, sbi return value {:?}", sbi_ret);
@@ -50,7 +57,7 @@ pub extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
     } else {
         println!("<< Test-kernel: All hart SBI test SUCCESS, shutdown");
         sbi::shutdown()
-    } 
+    }
 }
 
 fn test_base_extension() {
@@ -141,7 +148,7 @@ unsafe extern "C" fn entry() -> ! {
     addi    t0, t0, %pcrel_lo(1b)
     jr      t0
     ", 
-    boot_stack = sym BOOT_STACK, 
+    boot_stack = sym BOOT_STACK,
     rust_main = sym rust_main,
     options(noreturn))
 }

--- a/test-kernel/src/mm.rs
+++ b/test-kernel/src/mm.rs
@@ -7,9 +7,5 @@ static mut HEAP_SPACE: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 static HEAP: LockedHeap<32> = LockedHeap::empty();
 
 pub fn init_heap() {
-    unsafe {
-        HEAP
-            .lock()
-            .init(HEAP_SPACE.as_ptr() as usize, HEAP_SIZE)
-    }
+    unsafe { HEAP.lock().init(HEAP_SPACE.as_ptr() as usize, HEAP_SIZE) }
 }

--- a/test-kernel/src/sbi.rs
+++ b/test-kernel/src/sbi.rs
@@ -111,7 +111,12 @@ pub fn set_timer(time: usize) {
 const FUNCTION_IPI_SEND_IPI: usize = 0x0;
 
 pub fn send_ipi(hart_mask: usize, hart_mask_base: usize) -> SbiRet {
-    sbi_call_2(EXTENSION_IPI, FUNCTION_IPI_SEND_IPI, hart_mask, hart_mask_base)
+    sbi_call_2(
+        EXTENSION_IPI,
+        FUNCTION_IPI_SEND_IPI,
+        hart_mask,
+        hart_mask_base,
+    )
 }
 
 const FUNCTION_HSM_HART_START: usize = 0x0;
@@ -120,7 +125,13 @@ const FUNCTION_HSM_HART_GET_STATUS: usize = 0x2;
 const FUNCTION_HSM_HART_SUSPEND: usize = 0x3;
 
 pub fn hart_start(hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
-    sbi_call_3(EXTENSION_HSM, FUNCTION_HSM_HART_START, hartid, start_addr, opaque)
+    sbi_call_3(
+        EXTENSION_HSM,
+        FUNCTION_HSM_HART_START,
+        hartid,
+        start_addr,
+        opaque,
+    )
 }
 
 pub fn hart_stop(hartid: usize) -> SbiRet {
@@ -132,7 +143,13 @@ pub fn hart_get_status(hartid: usize) -> SbiRet {
 }
 
 pub fn hart_suspend(suspend_type: u32, resume_addr: usize, opaque: usize) -> SbiRet {
-    sbi_call_3(EXTENSION_HSM, FUNCTION_HSM_HART_SUSPEND, suspend_type as usize, resume_addr, opaque)
+    sbi_call_3(
+        EXTENSION_HSM,
+        FUNCTION_HSM_HART_SUSPEND,
+        suspend_type as usize,
+        resume_addr,
+        opaque,
+    )
 }
 
 #[inline(always)]


### PR DESCRIPTION
- `0..max_hart_id` instead of `0..=max_hart_id`
- Format codes with rustfmt