### PR TITLE
rustsbi-qemu: instance based RustSBI interface with separate functions for legacy stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Modified
 
+- Use instance based RustSBI interface, with separate functions for legacy stdio
 - Update sbi-testing to version 0.0.1
 - Use crate os-xtask-utils version 0.0.0 in xtask builder
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "rustsbi"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf13b0e42eff2a49a410659b7f8cd1207df7e4e6138d26ee1df07b3159a72f9c"
+checksum = "99a419920f956be760611d66db2563120fd98b39d9d39ca61e0aac669c5a8175"
 dependencies = [
  "riscv",
  "sbi-spec",
@@ -256,6 +256,7 @@ dependencies = [
  "r0",
  "riscv",
  "rustsbi",
+ "sbi-spec",
  "spin",
  "uart_16550",
 ]

--- a/rustsbi-qemu/Cargo.toml
+++ b/rustsbi-qemu/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustsbi = { version = "0.3.0-rc.1", features = ["legacy"] }
+rustsbi = "0.3.0-rc.2"
+sbi-spec = { version = "0.0.4", features = ["legacy"] }
 riscv = "0.9.0"
 spin = "0.9"
 r0 = "1"

--- a/rustsbi-qemu/src/console.rs
+++ b/rustsbi-qemu/src/console.rs
@@ -1,0 +1,30 @@
+use crate::ns16550a::Ns16550a;
+use core::fmt::{Arguments, Write};
+use spin::Once;
+
+pub(crate) static STDOUT: Once<Ns16550a> = Once::new();
+
+pub(crate) fn init(out: Ns16550a) {
+    STDOUT.call_once(|| out);
+}
+
+#[doc(hidden)]
+pub fn _print(args: Arguments) {
+    STDOUT.wait().write_fmt(args).unwrap();
+}
+
+/// Prints to the debug output.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::console::_print(core::format_args!($($arg)*)));
+}
+
+/// Prints to the debug output with a new line.
+#[macro_export]
+macro_rules! println {
+    () => ($crate::print!("\r\n"));
+    ($($arg:tt)*) => {
+        $crate::console::_print(core::format_args!($($arg)*));
+        $crate::print!("\r\n");
+    }
+}

--- a/rustsbi-qemu/src/ns16550a.rs
+++ b/rustsbi-qemu/src/ns16550a.rs
@@ -1,5 +1,4 @@
-use core::fmt::Write;
-use rustsbi::legacy_stdio::LegacyStdio;
+use core::fmt;
 use spin::Mutex;
 use uart_16550::MmioSerialPort;
 
@@ -9,18 +8,21 @@ impl Ns16550a {
     pub unsafe fn new(base: usize) -> Self {
         Self(Mutex::new(MmioSerialPort::new(base)))
     }
-}
 
-impl LegacyStdio for Ns16550a {
-    fn getchar(&self) -> u8 {
+    #[inline]
+    pub(crate) fn getchar(&self) -> u8 {
         self.0.lock().receive()
     }
 
-    fn putchar(&self, ch: u8) {
+    #[inline]
+    pub(crate) fn putchar(&self, ch: u8) {
         self.0.lock().send(ch);
     }
+}
 
-    fn write_str(&self, s: &str) {
+impl fmt::Write for &Ns16550a {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
         self.0.lock().write_str(s).unwrap();
+        Ok(())
     }
 }


### PR DESCRIPTION
Now no extra global variables are used in RustSBI memory and RustSBI uses default features so it builds on stable Rust. Once asm_const and naked_functions get stablized, this project can be built entirely on stable Rust.