### PR TITLE
support print unicode characters

### DIFF
--- a/rustsbi-qemu/src/main.rs
+++ b/rustsbi-qemu/src/main.rs
@@ -272,7 +272,9 @@ extern "C" fn fast_handler(
             } else {
                 match a7 {
                     legacy::LEGACY_CONSOLE_PUTCHAR => {
-                        print!("{}", ctx.a0() as u8 as char);
+                        unsafe {
+                            print!("{}", char::from_u32_unchecked(ctx.a0() as u32));
+                        }
                         ret.error = 0;
                         ret.value = a1;
                     }


### PR DESCRIPTION
之前的实现中只能print ASCII字符，没有支持中文输出，所以提此PR支持unicode characters。

### 原理

Rust 中的 char 类型是 [Unicode Scalar Value](https://doc.rust-lang.org/std/primitive.char.html)，可以用一个u32表示，并存储在a0中。比如使用下面的调用方式

``` rust
pub fn console_putchar(c: char) {
    sbi_call(LEGACY_CONSOLE_PUTCHAR, 0, c as u32 as usize, 0);
}
```

在转换回char时 rust 提供了 [char::from_u32](https://doc.rust-lang.org/std/primitive.char.html#method.from_u32) 和 [char::from_u32_unchecked](https://doc.rust-lang.org/std/primitive.char.html#method.from_u32_unchecked) 两个方法。前者比后者多了一层校验。这里采用from_u32_unchecked忽略校验，因为编码的正确性可以在sbi_call的时保证。

附上输出的截图

<img width="608" alt="Screen Shot 2023-01-06 at 9 43 30 AM" src="https://user-images.githubusercontent.com/16667362/210912795-1b9c76b9-37b1-4a2c-a655-b5c60209aad6.png">

