### PR TITLE
fix compile error with rustc 1.77.0-nightly (62d7ed4a6 2024-01-11)

### DIFF
--- a/bench-kernel/src/main.rs
+++ b/bench-kernel/src/main.rs
@@ -33,8 +33,8 @@ extern "C" fn rust_main(hartid: usize, _dtb_pa: usize) -> ! {
         static mut ebss: u64;
     }
     unsafe {
-        let mut ptr = &mut sbss as *mut u64;
-        let end = &mut ebss as *mut u64;
+        let mut ptr = sbss as *mut u64;
+        let end = ebss as *mut u64;
         while ptr < end {
             ptr.write_volatile(0);
             ptr = ptr.offset(1);

--- a/rustsbi-qemu/src/main.rs
+++ b/rustsbi-qemu/src/main.rs
@@ -72,8 +72,8 @@ extern "C" fn rust_main(hartid: usize, opaque: usize) {
             static mut ebss: u64;
         }
         unsafe {
-            let mut ptr = &mut sbss as *mut u64;
-            let end = &mut ebss as *mut u64;
+            let mut ptr = sbss as *mut u64;
+            let end = ebss as *mut u64;
             while ptr < end {
                 ptr.write_volatile(0);
                 ptr = ptr.offset(1);

--- a/test-kernel/src/main.rs
+++ b/test-kernel/src/main.rs
@@ -40,8 +40,8 @@ extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
         static mut ebss: u64;
     }
     unsafe {
-        let mut ptr = &mut sbss as *mut u64;
-        let end = &mut ebss as *mut u64;
+        let mut ptr = sbss as *mut u64;
+        let end = ebss as *mut u64;
         while ptr < end {
             ptr.write_volatile(0);
             ptr = ptr.offset(1);


### PR DESCRIPTION
mutable reference of mutable static is discouraged for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447> reference of mutable static is a hard error from 2024 edition